### PR TITLE
More stable boot parameter replacement

### DIFF
--- a/create_ISO.bash
+++ b/create_ISO.bash
@@ -8,7 +8,7 @@ umount temp
 
 cp preseed.cfg ./iso
 
-sed -i "s+quiet+quiet priority=high locale=en_US.UTF-8 keymap=de file=/cdrom/preseed.cfg+g" iso/isolinux/txt.cfg iso/boot/grub/grub.cfg
+sed -i "s+---+--- priority=high locale=en_US.UTF-8 keymap=de file=/cdrom/preseed.cfg+g" iso/isolinux/txt.cfg iso/boot/grub/grub.cfg
 
 OUTPUT=proxmox_custom.iso
 xorriso \


### PR DESCRIPTION
Line of code in question:
```bash
sed -i "s+quiet+quiet priority=high locale=en_US.UTF-8 keymap=de file=/cdrom/preseed.cfg+g" iso/isolinux/txt.cfg iso/boot/grub/grub.cfg
```

I'm not sure if "quiet" is a stable item to replace. It's been [documented](https://www.debian.org/releases/forky/amd64/ch05s03.en.html) as early as [bookworm](https://www.debian.org/releases/bookworm/amd64/ch05s03.en.html) (and probably been around for a much longer while) that boot parameters are guarenteed to be after "---", so I think that's a more stable approach.